### PR TITLE
Removes explicit dependency on Rack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 MAINTAINER Education Team at Docker <education@docker.com>
 
 RUN apt-get update && apt-get install --no-install-recommends -y curl wget git ruby ruby-dev
-RUN gem install --no-ri --no-rdoc bundler sinatra faker i18n tilt rack rack-protection sinatra-reloader
+RUN gem install --no-ri --no-rdoc bundler sinatra faker i18n tilt rack-protection sinatra-reloader
 EXPOSE 9292
 WORKDIR /opt/namer
 CMD ["rackup", "--host", "0.0.0.0"]


### PR DESCRIPTION
The latest version of rack requires Ruby >= 2.2.2, so the build fails.

```
Step 4 : RUN gem install --no-ri --no-rdoc bundler sinatra faker i18n tilt rack rack-protection sinatra-reloader
 ---> Running in 5ed9d4b68edb
ERROR:  Error installing rack:
        rack requires Ruby version >= 2.2.2.
Successfully installed bundler-1.12.5
Successfully installed rack-1.6.4
Successfully installed tilt-2.0.5
Successfully installed rack-protection-1.5.3
Successfully installed sinatra-1.4.7
Successfully installed i18n-0.7.0
Successfully installed faker-1.6.5
Successfully installed i18n-0.7.0
Successfully installed tilt-2.0.5
Successfully installed rack-protection-1.5.3
Successfully installed backports-3.6.8
Successfully installed rack-test-0.6.3
Successfully installed multi_json-1.12.1
Successfully installed sinatra-contrib-1.4.7
Successfully installed sinatra-reloader-1.0
15 gems installed
The command '/bin/sh -c gem install --no-ri --no-rdoc bundler sinatra faker i18n tilt rack rack-protection sinatra-reloader' returned a non-zero code: 1
```

This commit removes the explicit dependency and let the rack-protection provide rack as a transitive dependency, which will not fail the build as it will pick a compatible version.

```
Step 4 : RUN gem install --no-ri --no-rdoc bundler sinatra faker i18n tilt rack-protection sinatra-reloader
 ---> Running in fa72ebcff776
Successfully installed bundler-1.12.5
Successfully installed rack-1.6.4
Successfully installed tilt-2.0.5
Successfully installed rack-protection-1.5.3
Successfully installed sinatra-1.4.7
Successfully installed i18n-0.7.0
Successfully installed faker-1.6.5
Successfully installed i18n-0.7.0
Successfully installed tilt-2.0.5
Successfully installed rack-protection-1.5.3
Successfully installed backports-3.6.8
Successfully installed rack-test-0.6.3
Successfully installed multi_json-1.12.1
Successfully installed sinatra-contrib-1.4.7
Successfully installed sinatra-reloader-1.0
15 gems installed
 ---> 85b56e326c59
```
